### PR TITLE
References added, Images edited, Login edited

### DIFF
--- a/components/AuthButton.js
+++ b/components/AuthButton.js
@@ -13,23 +13,23 @@ export default () => {
       {!session ? (
         <button
           onClick={handleSignIn}
-          className="flex items-center justify-center bg-white border border-gray-300 text-gray-700 font-bold py-2 px-6 rounded-full shadow-lg transition duration-300 ease-in-out hover:bg-gray-100"
+          className="flex items-center justify-center bg-white text-gray-700 font-medium py-3 px-6 rounded-lg shadow-md transition duration-500 hover:shadow-lg hover:border-blue-500 border border-transparent"
         >
           <Image
             src="/google.png"
             alt="Google Logo"
-            width={40}
-            height={40}
-            className="mr-2"
+            width={20}
+            height={20}
+            className="mr-3"
           />
-          Sign in with Google
+          <span className="text-sm">Sign in with Google</span>
         </button>
       ) : (
         <div className="text-center">
-          <p className="text-white text-xl mb-4">Welcome, {session.user.name}!</p>
+          <p className="text-gray-800 text-lg mb-4">Welcome, {session.user.name}!</p>
           <button
             onClick={() => signOut()}
-            className="bg-red-500 hover:bg-red-600 text-white font-bold py-2 px-6 rounded-full shadow-lg transition duration-300 ease-in-out"
+            className="bg-red-500 hover:bg-red-600 text-white font-medium py-3 px-6 rounded-lg shadow-md transition duration-500 hover:shadow-lg"
           >
             Sign out
           </button>

--- a/pages/login.js
+++ b/pages/login.js
@@ -1,11 +1,29 @@
 import AuthButton from "@/components/AuthButton";
+import { GiOwl } from "react-icons/gi";
 
 export default function Home() {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-white">
-      <div className="bg-gradient-to-r from-blue-400 to-blue-600 rounded-3xl shadow-2xl p-10 max-w-md text-center">
-        <h1 className="text-4xl font-bold text-white mb-6">Noctua</h1>
-        <p className="text-white mb-8">Sign in to continue</p>
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-gray-900 via-blue-900 to-purple-900 relative overflow-hidden">
+      {/* Background Decorations */}
+      <div className="absolute top-0 left-0 w-[400px] h-[400px] bg-gradient-to-br from-blue-500 to-purple-700 rounded-full blur-3xl opacity-40 -translate-x-1/3 -translate-y-1/3"></div>
+      <div className="absolute bottom-0 right-0 w-[400px] h-[400px] bg-gradient-to-br from-pink-500 to-red-500 rounded-full blur-3xl opacity-40 translate-x-1/3 translate-y-1/3"></div>
+
+      {/* Auth Box */}
+      <div className="relative bg-gradient-to-r from-blue-600 to-blue-800 rounded-3xl shadow-md p-12 max-w-md w-full text-center z-10 transition-shadow duration-700 hover:shadow-lg hover:shadow-blue-400/30">
+        {/* Owl Logo and Title */}
+        <div className="flex items-center justify-center mb-6">
+          <div className="flex items-center justify-center bg-white p-3 rounded-full shadow-sm">
+            <GiOwl size={40} className="text-blue-600" />
+          </div>
+          <h1 className="text-5xl font-bold text-white ml-4">Noctua</h1>
+        </div>
+
+        {/* Description */}
+        <p className="text-lg text-gray-200 mb-10">
+          Unlock the wisdom of Noctua. Sign in to access your Minerva Assistant.
+        </p>
+
+        {/* Auth Button */}
         <AuthButton />
       </div>
     </div>


### PR DESCRIPTION
Hello good people of Noctua, we look a bit more like perplexity now haha! Here are some updates.

1. References are now hover-view and clickable reference circles and does not clutter the messages. Here are some views.
<img width="846" alt="Screenshot 2024-12-19 at 2 16 26 AM" src="https://github.com/user-attachments/assets/85a09144-834e-4230-bc37-598cb9753d21" />

2. Images now have edited captions that allow markdowns and are a bit more stylized. Here are some views:
<img width="846" alt="Screenshot 2024-12-19 at 2 17 08 AM" src="https://github.com/user-attachments/assets/7844abab-a40f-49ce-929e-0c562038a376" />

3. Edited the login page styling since it was an empty white page with Google Sign In. Here are some views:
<img width="1439" alt="Screenshot 2024-12-19 at 2 18 20 AM" src="https://github.com/user-attachments/assets/839f751b-1e11-4bf6-b81d-95e0616ab40b" />



**Issues**
As you can see in the second image, there is a frequent issue with images where the image is not found on imgur but the model still sends it, which is bad user experience. Is there any solution we can find?

**Future direction**
Your error message works well @AlaaAbbas22, I'll style it up so that we have an error bar like ChatGPT, just give me a day.